### PR TITLE
If user clicked on anchor in tooltip, open that before closing tooltip

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -139,6 +139,13 @@ var Autocomplete = function() {
     };
 
     this.blurListener = function(e) {
+        
+        // If the user clicked on an anchor in the tooltip, open that before
+        // we close the tooltip
+        if (e.relatedTarget && e.relatedTarget.nodeName == "A" && e.relatedTarget.href) {
+    		window.open(e.relatedTarget.href, "_blank");
+    	}
+
         // we have to check if activeElement is a child of popup because
         // on IE preventDefault doesn't stop scrollbar from being focussed
         var el = document.activeElement;


### PR DESCRIPTION
On blur of the autocomplete tooltip, if the user clicked on an anchor in the tooltip, open that anchor's href in a new tab instead of just ignoring the click.
